### PR TITLE
README: add VirtualBox section

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ You have the following topology:
 ```
 
 Your objective is to configure OSPF between rt1/rt2/rt3 to enable connectivity between 172.20.x.0/24 networks.
+#### 0. Setup VirtualBox
+Download from https://www.virtualbox.org/wiki/Downloads and install
 #### 1. Setup Vagrant
 Download from https://www.vagrantup.com/downloads.html and install
 #### 2. Pull repository


### PR DESCRIPTION
`Vagrant` will try to load `lxc` provider by default.

And in the same https://app.vagrantup.com/higebu/boxes/vyos has no any options for lxc.
Only for  libvirt & virtualbox.